### PR TITLE
Add missing species field to Character model

### DIFF
--- a/src/main/java/com/revature/models/Character.java
+++ b/src/main/java/com/revature/models/Character.java
@@ -38,7 +38,9 @@ public class Character {
     @Column(nullable = false)
     private String name;
 
-    // private Species species;
+    @NotNull
+    @OneToOne
+    private Species species;
 
     @URL
     private String imageUrl;


### PR DESCRIPTION
The lack of a relationship field between `Character` and `Species` gave me test errors when I reviewed #12, and it made me realize that I was lacking that field