### PR TITLE
Send 401 error on failed logins

### DIFF
--- a/src/main/java/com/revature/web/AuthController.java
+++ b/src/main/java/com/revature/web/AuthController.java
@@ -10,37 +10,38 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.revature.dto.Credentials;
+import com.revature.exceptions.AuthenticationException;
 import com.revature.models.User;
 import com.revature.service.UserService;
 import com.revature.util.JwtTokenManager;
 
 @RestController
-@CrossOrigin(origins="*", allowedHeaders="*")
+@CrossOrigin(origins = "*", allowedHeaders = "*")
 @RequestMapping("/login")
 public class AuthController {
-	private UserService userService;
-	private JwtTokenManager tokenManager;
-	
-	@Autowired
-	public AuthController(UserService userService, JwtTokenManager tokenManager) {
-		this.userService = userService;
-		this.tokenManager = tokenManager;
-	}
-	
-	@PostMapping
-	public User login(@RequestBody Credentials creds, HttpServletResponse response) {
-		User user = userService.authenticate(creds);
-		if(user != null) {
-			String token = tokenManager.issueToken(user);
-			
-			response.addHeader("auth-token", token);
-			response.addHeader("Access-Control-Expose-Headers", "auth-token");
-			response.setStatus(200);
-			
-			return user;
-		}else {
-			response.setStatus(401);
-			return null;
-		}
-	}
+
+    private UserService userService;
+    private JwtTokenManager tokenManager;
+
+    @Autowired
+    public AuthController(UserService userService, JwtTokenManager tokenManager) {
+        this.userService = userService;
+        this.tokenManager = tokenManager;
+    }
+
+    @PostMapping
+    public User login(@RequestBody Credentials creds, HttpServletResponse response) {
+        try {
+            User user = this.userService.authenticate(creds);
+            String token = this.tokenManager.issueToken(user);
+
+            response.addHeader("auth-token", token);
+            response.addHeader("Access-Control-Expose-Headers", "auth-token");
+            response.setStatus(200);
+        } catch (AuthenticationException e) {
+            response.setStatus(401);
+        }
+        return null;
+    }
+
 }


### PR DESCRIPTION
Unlike in the demo, we made `UserService.authenticate` to throw an exception instead of returning `null` when an incorrect username/password combo is passed to the login endpoint. This PR fixes the behavior of the said endpoint to send the correct status code (401 Unauthorized) to the client in that scenario.