### PR TITLE
Last-minute pom.xml fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,12 +107,11 @@
       <version>2.9.0</version>
       <scope>test</scope>
     </dependency>
-  </dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
-		</dependency>
-	</dependencies>
+  <dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter</artifactId>
+  </dependency>
+</dependencies>
 
   <build>
     <finalName>${project.artifactId}</finalName>


### PR DESCRIPTION
This should fix a build error introduced in either #25 or #26. It's always good idea to run `mvn clean package` before you submit pull requests and merge them into the main branch.